### PR TITLE
Add play, pause, restart tray features - fixes #19

### DIFF
--- a/app/main/tray.js
+++ b/app/main/tray.js
@@ -1,38 +1,115 @@
-const path = require('path')
-const electron = require('electron')
+const path = require('path');
+const electron = require('electron');
 
-const {app, Menu, Tray} = electron
+const { Menu, Tray } = electron;
+const IMG_FOLDER = path.join(__dirname, '../assets/icons/tray');
+const {
+	PLAY_SONG,
+	PAUSE_SONG,
+	RESTART_SONG
+} = require('../shared/js/actions/types');
 
-function createTray (onToggle, onClose) {
-	var imageFolder = path.join(__dirname, '../assets/icons/tray')
-	var trayImage
+const TRAY_EVENTS = {
+	[PLAY_SONG]: true,
+	[PAUSE_SONG]: true,
+	[RESTART_SONG]: true
+};
 
-	if(process.platform == 'win32') {
-		trayImage = path.join(imageFolder, 'win', 'icon.ico')
-	} else if(process.platform == 'darwin') {
-		trayImage = path.join(imageFolder, 'osx', 'iconTemplate.png')
-	} else {
-		trayImage = path.join(imageFolder, 'png', 'icon.png')
-	}
-
-	trayIcon = new Tray(trayImage)
-	const contextMenu = Menu.buildFromTemplate([
-		{
-			label: 'Toggle Show/Hide',
-			click: onToggle
-		},
-		{
-			label: 'Quit',
-			click: onClose
-		}
-	])
-	trayIcon.on('click', onToggle)
-
-	trayIcon.setTitle('Ongaku')
-	trayIcon.setToolTip('Ongaku')
-	trayIcon.setContextMenu(contextMenu)
-
-	return trayIcon
+let trayImage;
+if (process.platform == 'win32') {
+	trayImage = path.join(IMG_FOLDER, 'win', 'icon.ico');
+} else if (process.platform == 'darwin') {
+	trayImage = path.join(IMG_FOLDER, 'osx', 'iconTemplate.png');
+} else {
+	trayImage = path.join(IMG_FOLDER, 'png', 'icon.png');
 }
 
-exports.create = createTray
+class OngakuTray {
+	constructor(onToggle, onClose) {
+		this._tray = new Tray(trayImage);
+		this._tray.on('click', onToggle);
+		this._tray.setTitle('Ongaku');
+		this._tray.setToolTip('Ongaku');
+
+		this._onToggle = onToggle;
+		this._onClose = onClose;
+		this._initContextMenu();
+
+		this._isPlaying = true;
+		this._events = {};
+	}
+
+	_initContextMenu(playPauseLabel) {
+		this._tray.setContextMenu(
+			this._getMenu(playPauseLabel || 'Pause')
+		);
+	}
+
+	_getMenu(playPauseLabel) {
+		const menu = Menu.buildFromTemplate([
+			{
+				label: playPauseLabel,
+				click: () => this._onPlayPause()
+			},
+			{
+				label: 'Restart',
+				click: () => this._onRestart()
+			},
+			{
+				label: 'Toggle Show/Hide',
+				click: () => this._onToggle()
+			},
+			{
+				label: 'Quit',
+				click: () => this._onClose()
+			}
+		]);
+		return menu;
+	}
+
+	_onPlayPause() {
+		this.dispatchAction(
+			(this._isPlaying) ? PAUSE_SONG : PLAY_SONG
+		);
+	}
+
+	_onRestart() {
+		this.dispatchAction(RESTART_SONG);
+	}
+
+	handleAction(action) {
+		switch(action.type) {
+			case PLAY_SONG:
+				this._isPlaying = true;
+				this._tray.setToolTip(action.song);
+				// must rebuild the menu for Linux to take the update
+				this._initContextMenu('Pause');
+				break;
+			case PAUSE_SONG:
+				this._isPlaying = false;
+				// must rebuild the menu for Linux to take the update
+				this._initContextMenu('Play');
+				break;
+			default:
+				// do nothing
+		}
+	}
+
+	dispatchAction(type) {
+		if (this._events[type]) {
+			this._events[type].forEach((handler) => {
+				if (typeof handler === 'function') {
+					handler();
+				}
+			});
+		}
+	}
+
+	on(event, handler) {
+		if (TRAY_EVENTS[event]) {
+			this._events[event] = (this._events[event] || []).concat(handler);
+		}
+	}
+}
+
+module.exports = OngakuTray;

--- a/app/renderer/index.html
+++ b/app/renderer/index.html
@@ -10,6 +10,8 @@
 	<body>
 
 		<webview src="https://ongaku.js.org" preload="js/preload.js"></webview>
+
+		<script src="js/main.js"></script>
 		
 	</body>
 

--- a/app/renderer/js/main.js
+++ b/app/renderer/js/main.js
@@ -1,0 +1,20 @@
+const { ipcRenderer } = require('electron');
+
+window.onload = () => {
+  const webview = document.querySelector('webview');
+  webview.addEventListener('dom-ready', () => {
+    webview.openDevTools();
+
+    ipcRenderer.on('@@play', () => {
+      webview.getWebContents().send('@@play');
+    });
+
+    ipcRenderer.on('@@pause', () => {
+      webview.getWebContents().send('@@pause');
+    });
+
+    ipcRenderer.on('@@restart', () => {
+      webview.getWebContents().send('@@restart');
+    });
+  });
+}

--- a/app/renderer/js/preload.js
+++ b/app/renderer/js/preload.js
@@ -5,6 +5,31 @@
 
     https://electron.atom.io/docs/api/webview-tag/#preload
  */
+const { ipcRenderer } = require('electron');
+const {
+  PLAY_SONG,
+  PAUSE_SONG,
+  RESTART_SONG
+} = require('../../shared/js/actions/types');
+const {
+  playSong,
+  pauseSong
+} = require('../../shared/js/actions/creators');
+
+ipcRenderer.on(PLAY_SONG, (event) => {
+  document.querySelector('audio').play();
+});
+
+ipcRenderer.on(PAUSE_SONG, (event) => {
+  document.querySelector('audio').pause();
+});
+
+ipcRenderer.on(RESTART_SONG, (event) => {
+  const audio = document.querySelector('audio');
+  audio.currentTime = 0;
+  audio.play();
+});
+
 window.onload = () => {
   const songs = (window.osts || []).concat(window.openings, window.endings);
 
@@ -34,7 +59,10 @@ window.onload = () => {
   const audio = document.querySelector('audio');
 
   // reset current song so play after pause shows notification
-  audio.addEventListener('pause', () => currentSong = '');
+  audio.addEventListener('pause', () => {
+    ipcRenderer.send('message', pauseSong(currentSong));
+    currentSong = '';
+  });
 
   audio.addEventListener('playing', (e)=> {
     let src = e && e.target && e.target.currentSrc;
@@ -42,6 +70,7 @@ window.onload = () => {
     if (songName && songName !== currentSong) {
       currentSong = songName;
       notify('Now playing', songName);
+      ipcRenderer.send('message', playSong(songName));
     }
   });
 };

--- a/app/shared/js/actions/creators.js
+++ b/app/shared/js/actions/creators.js
@@ -1,0 +1,19 @@
+const {
+  PLAY_SONG,
+  PAUSE_SONG
+} = require('./types');
+
+const playSong = (song) => ({
+  type: PLAY_SONG,
+  song
+});
+
+const pauseSong = (song) => ({
+  type: PAUSE_SONG,
+  song
+});
+
+module.exports = {
+    playSong,
+    pauseSong
+};

--- a/app/shared/js/actions/types.js
+++ b/app/shared/js/actions/types.js
@@ -1,0 +1,5 @@
+module.exports = {
+  PAUSE_SONG: '@@pause',
+  PLAY_SONG: '@@play',
+  RESTART_SONG: '@@restart'
+};


### PR DESCRIPTION
I haven't done any testing on Windows yet, but I wanted to throw up the PR to get some feedback. I'll update with any changes necessary to accommodate Windows shortly. Let me know what you think of the approach!

P.S. - There's a small bug where the first song doesn't update the tray tooltip. This appears to be because the event listeners in the preload script are added _after_ the first song is triggered by the web app (so it never propagates to the tray). I'm still investigating how to get around that, but let me know if you have any thoughts.