### PR TITLE
Fix app focus on Windows when notification is clicked

### DIFF
--- a/app/main/index.js
+++ b/app/main/index.js
@@ -4,7 +4,13 @@ const path = require('path')
 const electron = require('electron')
 const tray = require('./tray.js')
 
-const {app, BrowserWindow, globalShortcut, webContents} = electron
+const {
+	app,
+	BrowserWindow,
+	globalShortcut,
+	ipcMain,
+	webContents
+} = electron
 
 // Prevent window and tray from being garbage collected
 let mainWindow
@@ -68,6 +74,12 @@ function createMainWindow () {
 	})
 	return win
 }
+
+ipcMain.on('focus', () => {
+	if (mainWindow) {
+		mainWindow.focus()
+	}
+})
 
 app.on('window-all-closed', () => {
 	if (process.platform !== 'darwin') {

--- a/app/renderer/js/preload.js
+++ b/app/renderer/js/preload.js
@@ -29,7 +29,7 @@ window.onload = () => {
     const options = { body };
     let noti = new Notification(title, options);
     noti.addEventListener('click', () => {
-      window.focus();
+      ipcRenderer.send('focus', true);
     });
   };
 
@@ -66,7 +66,7 @@ window.onload = () => {
     if (songName && songName !== currentSong) {
       currentSong = songName;
 
-      // notify('Now playing', currentSong);
+      notify('Now playing', currentSong);
       updateToolTip(currentSong, 'playing')
     }
   });


### PR DESCRIPTION
Re-enabling notifications and using a more universal approach to focusing the app window when the notification is clicked.